### PR TITLE
fix: ヘッダーロゴの垂直位置を調整

### DIFF
--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -2,4 +2,5 @@
     margin-top: 15px;
     margin-left: 20px;
     vertical-align: middle;
+    *vertical-align: auto; /* IE用のフォールバック */
 }

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -1,4 +1,5 @@
 .header-logo {
-    margin-top: 10px;
+    margin-top: 15px;
     margin-left: 20px;
+    vertical-align: middle;
 }


### PR DESCRIPTION
## 概要
ヘッダーのロゴが上にずれていた問題を修正しました。

## 変更内容
- ロゴのmargin-topを10pxから15pxに調整
- vertical-align: middleを追加して垂直中央揃えに

## 確認項目
- [ ] 各ブラウザで表示確認済み
(Chrome, Firefox, Safari)
- [ ] モバイル表示でも問題ないことを確認
- [ ] 関連するコンポーネントに影響がないことを確認

## スクリーンショット
### Before
![修正前のスクリーンショット](...)

### After
![修正後のスクリーンショット](...)

## 関連Issue
Fixes #123
